### PR TITLE
TAT: api change, use vector of string as name directly now

### DIFF
--- a/include/net/tensor_tool.hpp
+++ b/include/net/tensor_tool.hpp
@@ -7,18 +7,16 @@
 namespace net{
 	namespace tensor{
 		template <typename T>
-		using Tensor=TAT::Tensor<T,TAT::NoSymmetry>;
+		using Tensor=TAT::Tensor<T,TAT::NoSymmetry,std::string>;
 
 		Tensor<double> init_site_rand(const std::vector<std::string> & str_inds, const unsigned int D,const double min,const double max,std::default_random_engine & R){
 
 			auto distribution = std::uniform_real_distribution<double>(min,max);
-			std::vector<TAT::Name> inds;
 			std::vector<unsigned int> dims;
 			for (auto& ind:str_inds){
-				inds.push_back(ind);
 				dims.push_back(D);
 			}
-			Tensor<double> result(inds,{dims.begin(), dims.end()});
+			Tensor<double> result(str_inds,{dims.begin(), dims.end()});
 			return result.set([&distribution, &R]() { return distribution(R); });
 		}
 


### PR DESCRIPTION
TAT support name type as tensor's [third template argument](https://github.com/hzhangxyz/TAT/blob/TAT/include/TAT/tensor.hpp#L90) now(https://github.com/hzhangxyz/TAT/commit/ee4bd869a5317ff3b11f57cd09f64d4abd61b1ce).
Original `TAT::Name` is renamed to `TAT::DefaultName`, so use it instead of TAT::Name.


Detail:
tensor's thrid template argument Name could be `std::string` or `TAT::FastName`.
if `TAT_USE_SIMPLE_NAME` is defined, `TAT::DefaultName` is alias to `std::string`, if undefined, it is alias to `TAT::FastName`.(see https://github.com/hzhangxyz/TAT/blob/TAT/include/TAT/name.hpp#L100)


BTW:
I am using branch `TAT`, not master branch now. Don't work on branch master(https://github.com/hzhangxyz/TAT/commit/7ac15ec6d6003c8471412d9ee2069c9b8bc96de5)